### PR TITLE
Updated the managed policy name for cloudtrail

### DIFF
--- a/scripts/prerequisites/create-iam-resources_for_tooling_account.sh
+++ b/scripts/prerequisites/create-iam-resources_for_tooling_account.sh
@@ -88,7 +88,7 @@ EOF
   aws iam create-role --profile aws_sample_central_tooling --role-name $cloud_ops_role --assume-role-policy-document file://trust_policy.json
   aws iam attach-role-policy --profile aws_sample_central_tooling --policy-arn arn:aws:iam::aws:policy/AWSCodeCommitPowerUser --role-name $cloud_ops_role
   aws iam attach-role-policy --profile aws_sample_central_tooling --policy-arn arn:aws:iam::aws:policy/AWSConfigUserAccess --role-name $cloud_ops_role
-  aws iam attach-role-policy --profile aws_sample_central_tooling --policy-arn arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess --role-name $cloud_ops_role
+  aws iam attach-role-policy --profile aws_sample_central_tooling --policy-arn arn:aws:iam::aws:policy/AWSCloudTrail_ReadOnlyAccess --role-name $cloud_ops_role
   aws iam attach-role-policy --profile aws_sample_central_tooling --policy-arn arn:aws:iam::aws:policy/AWSCodeBuildReadOnlyAccess --role-name $cloud_ops_role
   aws iam attach-role-policy --profile aws_sample_central_tooling --policy-arn arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess --role-name $cloud_ops_role
   # As needed for the use case, you can use AWSCodePipelineApproverAccess instead that's more restricted


### PR DESCRIPTION
### Update:
**File:** /scripts/prerequisites/create-iam-resources_for_tooling_account.sh
**Change:** Updated "AWSCloudTrailReadOnlyAccess" to "AWSCloudTrail_ReadOnlyAccess"
**Reason:** CloudTrail changed the name of the AWSCloudTrailReadOnlyAccess policy to AWSCloudTrail_ReadOnlyAccess after June 6, 2022
**Reference:** https://docs.aws.amazon.com/awscloudtrail/latest/userguide/security-iam-awsmanpol.html#security-iam-awsmanpol-updates


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
