### PR TITLE
Fix for syntax error when REGION_TFVARS is set due to quotation marks

### DIFF
--- a/modules/regional/buildspec-terraform_tflint.yml
+++ b/modules/regional/buildspec-terraform_tflint.yml
@@ -44,7 +44,7 @@ phases:
       - export TEAM=$(echo $TAG | cut -d/ -f2)
       - export TARGET_MODULE=$(if [[ ${TARGET_DEPLOYMENT_SCOPE} == *"global"* ]];then echo "module.global"; else echo "module.regional"; fi)
       - export REGION=$(if [[ ${TARGET_DEPLOYMENT_SCOPE} == *"global"* ]];then echo "${GLOBAL_RESOURCE_DEPLOY_FROM_REGION}"; else echo "${TARGET_DEPLOYMENT_SCOPE}"; fi)
-      - export REGION_TFVARS=$([ -s "environments/${ENV}/${TEAM}/${REGION}.tfvars" ] && echo "-var-file \"environments/${ENV}/${TEAM}/${REGION}.tfvars\"" || echo "")
+      - export REGION_TFVARS=$([ -s "environments/${ENV}/${TEAM}/${REGION}.tfvars" ] && echo "-var-file environments/${ENV}/${TEAM}/${REGION}.tfvars" || echo "")
       - echo "ENV=${ENV}"
       - echo "TEAM=${TEAM}"
       - echo "TARGET_DEPLOYMENT_SCOPE=${TARGET_DEPLOYMENT_SCOPE}"

--- a/scripts/run-tf-prod-destroy.sh
+++ b/scripts/run-tf-prod-destroy.sh
@@ -46,6 +46,6 @@ echo "terraform init -reconfigure -backend-config="key=$TEAM/$ENV-$TARGET_DEPLOY
 terraform init -reconfigure -backend-config="key=$TEAM/$ENV-$TARGET_DEPLOYMENT_SCOPE/terraform.tfstate" -backend-config="region=$tf_state_region" -backend-config="bucket=$tf_backend_config_prefix-$ENV" -backend-config="dynamodb_table=$tf_backend_config_prefix-lock-$ENV" -backend-config="encrypt=true"
 terraform fmt
 terraform validate
-REGION_TFVARS=$([ -s "environments/${ENV}/${TEAM}/${REGION}.tfvars" ] && echo "-var-file \"environments/${ENV}/${TEAM}/${REGION}.tfvars\"" || echo "")
+REGION_TFVARS=$([ -s "environments/${ENV}/${TEAM}/${REGION}.tfvars" ] && echo "-var-file environments/${ENV}/${TEAM}/${REGION}.tfvars" || echo "")
 echo "terraform plan -var-file "environments/${ENV}/${TEAM}/variables.tfvars" ${REGION_TFVARS} -var "env=${ENV}" -var "region=${REGION}" -var "tf_backend_config_prefix=${tf_backend_config_prefix}" -var "global_resource_deploy_from_region=${global_resource_deploy_from_region}" -target ${TARGET_MODULE} -out=tfplan"
 terraform plan -destroy -var-file "environments/${ENV}/${TEAM}/variables.tfvars" ${REGION_TFVARS} -var "env=${ENV}" -var "region=${REGION}" -var "tf_backend_config_prefix=${tf_backend_config_prefix}" -var "global_resource_deploy_from_region=${global_resource_deploy_from_region}" -target ${TARGET_MODULE} -out=tfplan -compact-warnings

--- a/scripts/run-tf-prod-global-destroy.sh
+++ b/scripts/run-tf-prod-global-destroy.sh
@@ -45,6 +45,6 @@ echo "terraform init -reconfigure -backend-config="key=$TEAM/$ENV-$TARGET_DEPLOY
 terraform init -reconfigure -backend-config="key=$TEAM/$ENV-$TARGET_DEPLOYMENT_SCOPE/terraform.tfstate" -backend-config="region=$tf_state_region" -backend-config="bucket=$tf_backend_config_prefix-$ENV" -backend-config="dynamodb_table=$tf_backend_config_prefix-lock-$ENV" -backend-config="encrypt=true"
 terraform fmt
 terraform validate
-REGION_TFVARS=$([ -s "environments/${ENV}/${TEAM}/${REGION}.tfvars" ] && echo "-var-file \"environments/${ENV}/${TEAM}/${REGION}.tfvars\"" || echo "")
+REGION_TFVARS=$([ -s "environments/${ENV}/${TEAM}/${REGION}.tfvars" ] && echo "-var-file environments/${ENV}/${TEAM}/${REGION}.tfvars" || echo "")
 echo "terraform plan -var-file "environments/${ENV}/${TEAM}/variables.tfvars" ${REGION_TFVARS} -var "env=${ENV}" -var "region=${REGION}" -var "tf_backend_config_prefix=${tf_backend_config_prefix}" -var "global_resource_deploy_from_region=${global_resource_deploy_from_region}" -target ${TARGET_MODULE} -out=tfplan"
 terraform plan -destroy -var-file "environments/${ENV}/${TEAM}/variables.tfvars" ${REGION_TFVARS} -var "env=${ENV}" -var "region=${REGION}" -var "tf_backend_config_prefix=${tf_backend_config_prefix}" -var "global_resource_deploy_from_region=${global_resource_deploy_from_region}" -target ${TARGET_MODULE} -out=tfplan -compact-warnings

--- a/scripts/run-tf-prod-global.sh
+++ b/scripts/run-tf-prod-global.sh
@@ -45,6 +45,6 @@ echo "terraform init -reconfigure -backend-config="key=$TEAM/$ENV-$TARGET_DEPLOY
 terraform init -reconfigure -backend-config="key=$TEAM/$ENV-$TARGET_DEPLOYMENT_SCOPE/terraform.tfstate" -backend-config="region=$tf_state_region" -backend-config="bucket=$tf_backend_config_prefix-$ENV" -backend-config="dynamodb_table=$tf_backend_config_prefix-lock-$ENV" -backend-config="encrypt=true"
 terraform fmt
 terraform validate
-REGION_TFVARS=$([ -s "environments/${ENV}/${TEAM}/${REGION}.tfvars" ] && echo "-var-file \"environments/${ENV}/${TEAM}/${REGION}.tfvars\"" || echo "")
+REGION_TFVARS=$([ -s "environments/${ENV}/${TEAM}/${REGION}.tfvars" ] && echo "-var-file environments/${ENV}/${TEAM}/${REGION}.tfvars" || echo "")
 echo "terraform plan -var-file "environments/${ENV}/${TEAM}/variables.tfvars" ${REGION_TFVARS} -var "env=${ENV}" -var "region=${REGION}" -var "tf_backend_config_prefix=${tf_backend_config_prefix}" -var "global_resource_deploy_from_region=${global_resource_deploy_from_region}" -target ${TARGET_MODULE} -out=tfplan"
 terraform plan -var-file "environments/${ENV}/${TEAM}/variables.tfvars" ${REGION_TFVARS} -var "env=${ENV}" -var "region=${REGION}" -var "tf_backend_config_prefix=${tf_backend_config_prefix}" -var "global_resource_deploy_from_region=${global_resource_deploy_from_region}" -target ${TARGET_MODULE} -out=tfplan -compact-warnings

--- a/scripts/run-tf-prod.sh
+++ b/scripts/run-tf-prod.sh
@@ -46,6 +46,6 @@ echo "terraform init -reconfigure -backend-config="key=$TEAM/$ENV-$TARGET_DEPLOY
 terraform init -reconfigure -backend-config="key=$TEAM/$ENV-$TARGET_DEPLOYMENT_SCOPE/terraform.tfstate" -backend-config="region=$tf_state_region" -backend-config="bucket=$tf_backend_config_prefix-$ENV" -backend-config="dynamodb_table=$tf_backend_config_prefix-lock-$ENV" -backend-config="encrypt=true"
 terraform fmt
 terraform validate
-REGION_TFVARS=$([ -s "environments/${ENV}/${TEAM}/${REGION}.tfvars" ] && echo "-var-file \"environments/${ENV}/${TEAM}/${REGION}.tfvars\"" || echo "")
+REGION_TFVARS=$([ -s "environments/${ENV}/${TEAM}/${REGION}.tfvars" ] && echo "-var-file environments/${ENV}/${TEAM}/${REGION}.tfvars" || echo "")
 echo "terraform plan -var-file "environments/${ENV}/${TEAM}/variables.tfvars" ${REGION_TFVARS} -var "env=${ENV}" -var "region=${REGION}" -var "tf_backend_config_prefix=${tf_backend_config_prefix}" -var "global_resource_deploy_from_region=${global_resource_deploy_from_region}" -target ${TARGET_MODULE} -out=tfplan"
 terraform plan -var-file "environments/${ENV}/${TEAM}/variables.tfvars" ${REGION_TFVARS} -var "env=${ENV}" -var "region=${REGION}" -var "tf_backend_config_prefix=${tf_backend_config_prefix}" -var "global_resource_deploy_from_region=${global_resource_deploy_from_region}" -target ${TARGET_MODULE} -out=tfplan -compact-warnings


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/aws-multi-region-cicd-with-terraform/issues/13

*Description of changes:*
Fixes syntax error when REGION_TFVARS is set due to quotation marks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
